### PR TITLE
add tomcat's pid file location

### DIFF
--- a/jira.service
+++ b/jira.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service] 
 Type=forking
+PIDFile=/opt/atlassian/jira/work/catalina.pid
 ExecStart=/opt/atlassian/jira/bin/start-jira.sh
 ExecStop=/opt/atlassian/jira/bin/stop-jira.sh
 


### PR DESCRIPTION
systemd can identify if the service started successfully or not by pid when service type is forking. 
If this pidfile information is missing, systemd will see this service is failed to start, so execute stop script soon after.

the same is applied to confluence.
