### PR TITLE
Add syslog.target to 'After:' line.

### DIFF
--- a/jira.service
+++ b/jira.service
@@ -1,6 +1,6 @@
 [Unit] 
 Description=Jira Issue & Project Tracking Software
-After=network.target
+After=syslog.target network.target
 
 [Service] 
 Type=forking


### PR DESCRIPTION
Inspiration for this change is from this Atlassian answer:

https://answers.atlassian.com/questions/147102/instead-of-init-d-use-systemctl
