### PR TITLE
Update PID file for Bitbucket version 5

### DIFF
--- a/bitbucket.service
+++ b/bitbucket.service
@@ -5,7 +5,7 @@
 	[Service]
 	Type=forking
 	User=bitbucket
-	PIDFile=/opt/atlassian/bitbucket/work/catalina.pid
+	PIDFile=/var/atlassian/application-data/bitbucket/log/bitbucket.pid
 	ExecStart=/opt/atlassian/bitbucket/bin/start-bitbucket.sh
 	ExecStop=/opt/atlassian/bitbucket/bin/stop-bitbucket.sh
 	 


### PR DESCRIPTION
In Bitbucket version 5 the standard location of the PID file has changed to:
/var/atlassian/application-data/bitbucket/log/bitbucket.pid